### PR TITLE
Problem disabling Combinational Loop Detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,8 @@ Session.vim
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio
 
 *.iml
+# don't pickup scala worksheets from intellij
+*.sc
 
 ## Directory-based project format:
 .idea/

--- a/src/main/scala/firrtl_interpreter/FirrtlRepl.scala
+++ b/src/main/scala/firrtl_interpreter/FirrtlRepl.scala
@@ -3,7 +3,6 @@ package firrtl_interpreter
 
 import java.io.File
 
-import firrtl.ExecutionOptionsManager
 import firrtl_interpreter.vcd.VCD
 
 import scala.collection.mutable.ArrayBuffer
@@ -24,7 +23,7 @@ abstract class Command(val name: String) {
   }
 }
 
-class FirrtlRepl(val optionsManager: ExecutionOptionsManager with HasReplConfig with HasInterpreterOptions) {
+class FirrtlRepl(val optionsManager: InterpreterOptionsManager with HasReplConfig) {
   val replConfig: ReplConfig = optionsManager.replConfig
   val interpreterOptions: InterpreterOptions = optionsManager.interpreterOptions
 
@@ -58,7 +57,7 @@ class FirrtlRepl(val optionsManager: ExecutionOptionsManager with HasReplConfig 
   var replVcdController: Option[ReplVcdController] = None
 
   def loadSource(input: String): Unit = {
-    currentInterpreterOpt = Some(FirrtlTerp(input, interpreterOptions))
+    currentInterpreterOpt = Some(FirrtlTerp(input, optionsManager))
     currentInterpreterOpt.foreach { _=>
       interpreter.evaluator.allowCombinationalLoops = interpreterOptions.allowCycles
       interpreter.evaluator.useTopologicalSortedKeys = interpreterOptions.setOrderedExec
@@ -1060,13 +1059,13 @@ class FirrtlRepl(val optionsManager: ExecutionOptionsManager with HasReplConfig 
 }
 
 object FirrtlRepl {
-  def execute(optionsManager: ExecutionOptionsManager with HasReplConfig with HasInterpreterOptions): Unit = {
+  def execute(optionsManager: InterpreterOptionsManager with HasReplConfig): Unit = {
     val repl = new FirrtlRepl(optionsManager)
     repl.run()
   }
 
   def main(args: Array[String]): Unit = {
-    val optionsManager = new ExecutionOptionsManager("firrtl-repl") with HasReplConfig with HasInterpreterOptions
+    val optionsManager = new InterpreterOptionsManager with HasReplConfig
 
     if(optionsManager.parse(args)) {
       val repl = new FirrtlRepl(optionsManager)

--- a/src/main/scala/firrtl_interpreter/InterpretiveTester.scala
+++ b/src/main/scala/firrtl_interpreter/InterpretiveTester.scala
@@ -1,8 +1,6 @@
 // See LICENSE for license details.
 package firrtl_interpreter
 
-import firrtl.ExecutionOptionsManager
-
 /**
   * Works a lot like the chisel classic tester compiles a firrtl input string
   * and allows poke, peek, expect and step
@@ -16,15 +14,12 @@ import firrtl.ExecutionOptionsManager
   * @param input              a firrtl program contained in a string
   * @param optionsManager     collection of options for the interpreter
   */
-class InterpretiveTester(
-    input: String,
-    optionsManager: ExecutionOptionsManager with HasInterpreterOptions =
-      new ExecutionOptionsManager("firrtl-interpreter") with HasInterpreterOptions) {
+class InterpretiveTester(input: String, optionsManager: HasInterpreterSuite = new InterpreterOptionsManager) {
   var expectationsMet = 0
 
   firrtl_interpreter.random.setSeed(optionsManager.interpreterOptions.randomSeed)
 
-  val interpreter: FirrtlTerp                = FirrtlTerp(input, optionsManager.interpreterOptions)
+  val interpreter: FirrtlTerp                = FirrtlTerp(input, optionsManager)
   val interpreterOptions: InterpreterOptions = optionsManager.interpreterOptions
   val commonOptions: firrtl.CommonOptions    = optionsManager.commonOptions
 

--- a/src/main/scala/firrtl_interpreter/ToLoFirrtl.scala
+++ b/src/main/scala/firrtl_interpreter/ToLoFirrtl.scala
@@ -2,17 +2,16 @@
 
 package firrtl_interpreter
 
-import java.io.{StringWriter, Writer}
-
-import firrtl.LowFirrtlCompiler
+import firrtl._
 import firrtl.ir.Circuit
-import firrtl.ChirrtlForm
 
 object ToLoFirrtl {
-  def lower(c: Circuit): Circuit = {
+  def lower(c: Circuit,
+            optionsManager: ExecutionOptionsManager with HasFirrtlOptions with HasInterpreterOptions): Circuit = {
     val compiler = new LowFirrtlCompiler
 
-    val compileResult = compiler.compile(firrtl.CircuitState(c, ChirrtlForm), new StringWriter)
+    val annotationMap = AnnotationMap(optionsManager.firrtlOptions.annotations)
+    val compileResult = compiler.compileAndEmit(firrtl.CircuitState(c, ChirrtlForm, Some(annotationMap)))
     compileResult.circuit
   }
 }

--- a/src/main/scala/firrtl_interpreter/VcdReplayTester.scala
+++ b/src/main/scala/firrtl_interpreter/VcdReplayTester.scala
@@ -4,8 +4,8 @@ package firrtl_interpreter
 
 import java.io.File
 
-import firrtl.ExecutionOptionsManager
-import firrtl_interpreter.vcd.{Wire, VCD}
+import firrtl.{ExecutionOptionsManager}
+import firrtl_interpreter.vcd.{VCD, Wire}
 import logger.LazyLogging
 
 /**
@@ -251,6 +251,5 @@ trait HasVcdReplayOptions {
     .text("number of events to run")
 }
 
-class VcdReplayTesterOptions
-  extends ExecutionOptionsManager("golden-vcd-tester") with HasVcdReplayOptions with HasInterpreterOptions
+class VcdReplayTesterOptions extends InterpreterOptionsManager with HasVcdReplayOptions
 

--- a/src/test/scala/firrtl_interpreter/BlackBoxOutputSpec.scala
+++ b/src/test/scala/firrtl_interpreter/BlackBoxOutputSpec.scala
@@ -2,7 +2,6 @@
 
 package firrtl_interpreter
 
-import firrtl.ExecutionOptionsManager
 import firrtl.ir.Type
 import org.scalatest.{FreeSpec, Matchers}
 
@@ -99,7 +98,7 @@ class BlackBoxOutputSpec extends FreeSpec with Matchers {
 
       val factory = new FanOutAdderFactory
 
-      val optionsManager = new ExecutionOptionsManager("interpreter") with HasInterpreterOptions {
+      val optionsManager = new InterpreterOptionsManager {
         interpreterOptions = InterpreterOptions(blackBoxFactories = Seq(factory), randomSeed = 0L)
       }
       val tester = new InterpretiveTester(adderInput, optionsManager)
@@ -140,7 +139,7 @@ class BlackBoxOutputSpec extends FreeSpec with Matchers {
 
       val factory = new BlackBoxCounterFactory
 
-      val optionsManager = new ExecutionOptionsManager("interpreter") with HasInterpreterOptions {
+      val optionsManager = new InterpreterOptionsManager {
         interpreterOptions = InterpreterOptions(blackBoxFactories = Seq(factory), randomSeed = 0L)
       }
       val tester = new InterpretiveTester(input, optionsManager)

--- a/src/test/scala/firrtl_interpreter/LifeCellSpec.scala
+++ b/src/test/scala/firrtl_interpreter/LifeCellSpec.scala
@@ -1,7 +1,7 @@
 // See LICENSE for license details.
 package firrtl_interpreter
 
-import firrtl.{CommonOptions, ExecutionOptionsManager}
+import firrtl.CommonOptions
 import org.scalatest.{FlatSpec, Matchers}
 
 class LifeCellSpec extends FlatSpec with Matchers {
@@ -47,7 +47,7 @@ class LifeCellSpec extends FlatSpec with Matchers {
         |    io.is_alive <= T_36
         |      """.stripMargin
 
-    val optionsManager = new ExecutionOptionsManager("firrtl-interpreter") with HasInterpreterOptions {
+    val optionsManager = new InterpreterOptionsManager {
       interpreterOptions = InterpreterOptions(writeVCD = true)
       commonOptions = CommonOptions(targetDirName = "test_run_dir")
     }

--- a/src/test/scala/firrtl_interpreter/RegisterSpec.scala
+++ b/src/test/scala/firrtl_interpreter/RegisterSpec.scala
@@ -21,7 +21,10 @@ class RegisterSpec extends FlatSpec with Matchers {
         |
       """.stripMargin
 
-    val interpreter = FirrtlTerp(input, InterpreterOptions(setVerbose = true))
+    val optionsManager = new InterpreterOptionsManager {
+      val interpeterOptions = InterpreterOptions(setVerbose = true)
+    }
+    val interpreter = FirrtlTerp(input, optionsManager)
 
     def makeValue(value: BigInt): Concrete = ConcreteUInt(value, 1)
 

--- a/src/test/scala/firrtl_interpreter/real/BlackBoxRealSpec.scala
+++ b/src/test/scala/firrtl_interpreter/real/BlackBoxRealSpec.scala
@@ -2,7 +2,7 @@
 
 package firrtl_interpreter.real
 
-import firrtl.ExecutionOptionsManager
+import firrtl.{ExecutionOptionsManager, HasFirrtlOptions}
 import firrtl_interpreter._
 import org.scalatest.{FreeSpec, Matchers}
 
@@ -38,7 +38,7 @@ class BlackBoxRealSpec extends FreeSpec with Matchers {
 
     "addition should work expand instances as found" in {
 
-      val optionsManager = new ExecutionOptionsManager("interpreter") with HasInterpreterOptions {
+      val optionsManager = new InterpreterOptionsManager {
         interpreterOptions = InterpreterOptions(blackBoxFactories = Seq(new DspRealFactory), randomSeed = 0L)
       }
       val tester = new InterpretiveTester(adderInput, optionsManager)
@@ -54,7 +54,7 @@ class BlackBoxRealSpec extends FreeSpec with Matchers {
     }
 
     "poison should propagate through black boxes" in {
-      val optionsManager = new ExecutionOptionsManager("interpreter") with HasInterpreterOptions {
+      val optionsManager = new InterpreterOptionsManager {
         interpreterOptions = InterpreterOptions(blackBoxFactories = Seq(new DspRealFactory), randomSeed = 0L)
       }
       val tester = new InterpretiveTester(adderInput, optionsManager)
@@ -91,7 +91,7 @@ class BlackBoxRealSpec extends FreeSpec with Matchers {
         |    BBFIntPart_1.in <= io_a_node
       """.stripMargin
 
-    val optionsManager = new ExecutionOptionsManager("interpreter") with HasInterpreterOptions {
+    val optionsManager = new InterpreterOptionsManager {
       interpreterOptions = InterpreterOptions(blackBoxFactories = Seq(new DspRealFactory))
     }
     val tester = new InterpretiveTester(input, optionsManager)


### PR DESCRIPTION
The interpreter was not picking up the disable combinational loop detection command line flag.
The default initial lowering pass now picks up this flag.
This required a lot of manipulation of the optionsManager traits
Which affected many files in main and test.
Affected many imports as well.
Fixed flag which disabled default initial lowering pass
> This breaks API for chisel testers.  A matched PR from there must be done when this is done