### PR TITLE
Update sbt to 0.13.16; add Scala 2.12 support.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,31 @@
 // See LICENSE for license details.
 
+def scalacOptionsVersion(scalaVersion: String): Seq[String] = {
+  Seq() ++ {
+    // If we're building with Scala > 2.11, enable the compile option
+    //  switch to support our anonymous Bundle definitions:
+    //  https://github.com/scala/bug/issues/10047
+    CrossVersion.partialVersion(scalaVersion) match {
+      case Some((2, scalaMajor: Int)) if scalaMajor < 12 => Seq()
+      case _ => Seq("-Xsource:2.11")
+    }
+  }
+}
+
+def javacOptionsVersion(scalaVersion: String): Seq[String] = {
+  Seq() ++ {
+    // Scala 2.12 requires Java 8. We continue to generate
+    //  Java 7 compatible code for Scala 2.11
+    //  for compatibility with old clients.
+    CrossVersion.partialVersion(scalaVersion) match {
+      case Some((2, scalaMajor: Int)) if scalaMajor < 12 =>
+        Seq("-source", "1.7", "-target", "1.7")
+      case _ =>
+        Seq("-source", "1.8", "-target", "1.8")
+    }
+  }
+}
+
 name := "firrtl-interpreter"
 
 organization := "edu.berkeley.cs"
@@ -9,6 +35,8 @@ version := "1.1-SNAPSHOT"
 val chiselVersion = System.getProperty("chiselVersion", "3.0")
 
 scalaVersion := "2.11.11"
+
+crossScalaVersions := Seq("2.11.11", "2.12.3")
 
 resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots"),
@@ -31,3 +59,4 @@ libraryDependencies ++= Seq(
 //javaOptions in run ++= Seq(
     //"-Xms2G", "-Xmx4G", "-XX:MaxPermSize=1024M", "-XX:+UseConcMarkSweepGC")
 
+javacOptions ++= javacOptionsVersion(scalaVersion.value)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.15
+sbt.version = 0.13.16


### PR DESCRIPTION
To clean, test, and build Scala 2.11 and Scala 2.12 versions:
  % sbt +clean +test +publishLocal
NOTE: You need to be running Java 8 to build the 2.12 version.