### PR TITLE
Some optimizations

### DIFF
--- a/src/main/scala/firrtl_interpreter/executable/ExecutableCircuit.scala
+++ b/src/main/scala/firrtl_interpreter/executable/ExecutableCircuit.scala
@@ -72,7 +72,7 @@ object ExecutableCircuit {
 
     //    println(s"state 0 $state")
 
-    val instructions = Seq(
+    val instructions = Array[Assigner](
       AssignInt(state, state.getUInt("t_13"),
         GtInts(
           GetInt(state, state.getUInt("reg_x_out")).apply,
@@ -145,7 +145,7 @@ object ExecutableCircuit {
       )
     )
 
-    val regNextInstructions = Seq(
+    val regNextInstructions = Array(
       AssignInt(state, state.getUInt("reg_x_out"), GetInt(state, state.getUInt("reg_x_in")).apply),
       AssignInt(state, state.getUInt("reg_y_out"), GetInt(state, state.getUInt("reg_y_in")).apply)
     )
@@ -166,8 +166,16 @@ object ExecutableCircuit {
     var cycle = 0
 
     def step(): Unit = {
-      regNextInstructions.foreach { inst => inst() }
-      instructions.foreach { inst => inst() }
+      var i = 0
+      while (i < regNextInstructions.length) {
+        regNextInstructions(i)()
+        i += 1
+      }
+      i = 0
+      while (i < instructions.length) {
+        instructions(i)()
+        i += 1
+      }
       cycle += 1
     }
 

--- a/src/main/scala/firrtl_interpreter/executable/ExecutableCircuit.scala
+++ b/src/main/scala/firrtl_interpreter/executable/ExecutableCircuit.scala
@@ -201,10 +201,10 @@ object ExecutableCircuit {
       (x, depth)
     }
 
-    val values =
-      for {x <- 1 to 1000
-           y <- 1 to 1000
-      } yield (x, y, computeGcd(x, y)._1)
+    // val values =
+    //   for {x <- 1 to 1000
+    //        y <- 1 to 1000
+    //   } yield (x, y, computeGcd(x, y)._1)
 
     val startTime = System.nanoTime()
 
@@ -254,8 +254,8 @@ object ExecutableCircuit {
     }
 
     val values =
-      for {x <- 1 to 1000
-           y <- 1 to 1000
+      for {x <- 1 to 1500
+           y <- 1 to 1500
       } yield (x, y, computeGcd(x, y)._1)
 
     runOnce(values)


### PR DESCRIPTION
A got some speedup by doing things in more of a java way. Some of the things I did:
- Used array instead of seq
- Put value in integer array, not in a case class
- Eliminated as many hash table lookups as possible
- Don't use case class for assignment operators, use two arrays
- Use while loops where performance might matter

Obviously, this throws away a lot of the things that makes scala nice and maintainable. I see a pretty nice speedup, though, so it may be worth it. Strangely, when I run `Concrete` and `Executable` together, I don't see the speedup, but when I comment out `Executable` I see it go from low/mid 5 Mhz to just over 6. 