### PR TITLE
BlackBoxImplentation instances must be distinct due to internal state

### DIFF
--- a/src/main/scala/firrtl_interpreter/ExternalModule.scala
+++ b/src/main/scala/firrtl_interpreter/ExternalModule.scala
@@ -35,6 +35,7 @@ case class BlackBoxOutput(name: String,
   */
 abstract class BlackBoxImplementation {
   def name: String
+  @deprecated("Do not use.  This was formerly used to add BlackBox name to io, just use un-prefixed input names")
   def fullName(componentName: String): String = s"$name.$componentName"
 
   /**

--- a/src/main/scala/firrtl_interpreter/ExternalModule.scala
+++ b/src/main/scala/firrtl_interpreter/ExternalModule.scala
@@ -79,10 +79,10 @@ abstract class BlackBoxImplementation {
   * }}}
   */
 abstract class BlackBoxFactory {
-  val boxes: mutable.HashMap[String, BlackBoxImplementation] = new mutable.HashMap[String, BlackBoxImplementation]
+  var boxes: List[BlackBoxImplementation] = List.empty
 
   def add(blackBox: BlackBoxImplementation): BlackBoxImplementation = {
-    boxes(blackBox.name) = blackBox
+    boxes = blackBox :: boxes
     blackBox
   }
   def createInstance(instanceName: String, blackBoxName: String): Option[BlackBoxImplementation]
@@ -92,6 +92,6 @@ abstract class BlackBoxFactory {
     * cycle methods of each one
     */
   def cycle(): Unit = {
-    boxes.values.foreach { box => box.cycle() }
+    boxes.foreach { box => box.cycle() }
   }
 }

--- a/src/main/scala/firrtl_interpreter/real/DspRealBlackBox.scala
+++ b/src/main/scala/firrtl_interpreter/real/DspRealBlackBox.scala
@@ -22,7 +22,7 @@ abstract class DspRealTwoArgumentToDouble extends BlackBoxImplementation {
 
   def outputDependencies(outputName: String): Seq[(String)] = {
     outputName match {
-      case "out" => Seq(fullName("in1"), fullName("in2"))
+      case "out" => Seq("in1", "in2")
       case _ => Seq.empty
     }
   }
@@ -50,7 +50,7 @@ abstract class DspRealOneArgumentToDouble extends BlackBoxImplementation {
 
   def outputDependencies(outputName: String): Seq[(String)] = {
     outputName match {
-      case "out" => Seq(fullName("in"))
+      case "out" => Seq("in")
       case _ => Seq.empty
     }
   }
@@ -76,7 +76,7 @@ abstract class DspRealTwoArgumentToBoolean extends BlackBoxImplementation {
 
   def outputDependencies(outputName: String): Seq[(String)] = {
     outputName match {
-      case "out" => Seq(fullName("in1"), fullName("in2"))
+      case "out" => Seq("in1", "in2")
       case _ => Seq.empty
     }
   }
@@ -141,7 +141,7 @@ class DspRealIntPart(val name: String) extends DspRealOneArgumentToDouble {
 class DspRealToInt(val name: String) extends BlackBoxImplementation {
   def outputDependencies(outputName: String): Seq[(String)] = {
     outputName match {
-      case "out" => Seq(fullName("in"))
+      case "out" => Seq("in")
       case _ => Seq.empty
     }
   }
@@ -156,7 +156,7 @@ class DspRealToInt(val name: String) extends BlackBoxImplementation {
 class DspRealFromInt(val name: String) extends BlackBoxImplementation {
   def outputDependencies(outputName: String): Seq[(String)] = {
     outputName match {
-      case "out" => Seq(fullName("in"))
+      case "out" => Seq("in")
       case _ => Seq.empty
     }
   }

--- a/src/test/scala/firrtl_interpreter/BlackBoxOutputSpec.scala
+++ b/src/test/scala/firrtl_interpreter/BlackBoxOutputSpec.scala
@@ -182,7 +182,7 @@ class BlackBoxOutputSpec extends FreeSpec with Matchers {
         |    counter2 <= bbc2.counter
       """.stripMargin
 
-    "each counter should hold a different value" in {
+    "each counter should hold a different value in internal state" in {
 
       val factory = new BlackBoxCounterFactory
 


### PR DESCRIPTION
This fix
- More generally adds instance name as prefix to BB inputs
- Allows each black box to be a single instance.
- Deprecates the fullName function in BlackBoxImplementation