### PR TITLE
Will now write VCD log file even if errors or exceptions occur

### DIFF
--- a/src/main/scala/firrtl_interpreter/FirrtlTerp.scala
+++ b/src/main/scala/firrtl_interpreter/FirrtlTerp.scala
@@ -55,7 +55,7 @@ class FirrtlTerp(val ast: Circuit, val optionsManager: HasInterpreterSuite) exte
 
   val dependencyGraph = DependencyGraph(loweredAst, this)
   /**
-    * Once a stop has occured, the intepreter will not allow pokes until
+    * Once a stop has occured, the interpreter will not allow pokes until
     * the stop has been cleared
     */
   def clearStop(): Unit = {lastStopResult = None}
@@ -83,15 +83,22 @@ class FirrtlTerp(val ast: Circuit, val optionsManager: HasInterpreterSuite) exte
   setVerbose(interpreterOptions.setVerbose)
 
   def getValue(name: String): Concrete = {
-    assert(dependencyGraph.validNames.contains(name),
-      s"Error: getValue($name) is not an element of this circuit")
+    try {
+      assert(dependencyGraph.validNames.contains(name),
+        s"Error: getValue($name) is not an element of this circuit")
 
-    if(circuitState.isStale) {
+      if (circuitState.isStale) {
         evaluateCircuit()
       }
-    circuitState.getValue(name) match {
-      case Some(value) => value
-      case _ => throw InterpreterException(s"Error: getValue($name) returns value not found")
+      circuitState.getValue(name) match {
+        case Some(value) => value
+        case _ => throw InterpreterException(s"Error: getValue($name) returns value not found")
+      }
+    }
+    catch {
+      case e: Throwable =>
+        circuitState.writeVCD()
+        throw e
     }
   }
 
@@ -217,47 +224,54 @@ class FirrtlTerp(val ast: Circuit, val optionsManager: HasInterpreterSuite) exte
   }
 
   def cycle(showState: Boolean = false): Unit = {
-    log("interpreter cycle called " + "="*80)
-    if(checkStopped("cycle")) return
+    try {
+      log("interpreter cycle called " + "=" * 80)
+      if (checkStopped("cycle")) return
 
-    circuitState.vcdLowerClock()
-    circuitState.vcdRaiseClock()
+      circuitState.vcdLowerClock()
+      circuitState.vcdRaiseClock()
 
-    if(circuitState.isStale) {
-      log("interpreter cycle() called, state is stale, re-evaluate Circuit")
-      log(circuitState.prettyString())
+      if (circuitState.isStale) {
+        log("interpreter cycle() called, state is stale, re-evaluate Circuit")
+        log(circuitState.prettyString())
 
-      log(s"process reset")
-      evaluateCircuit()
-    }
-    else {
-      log(s"interpreter cycle() called, state is fresh")
-    }
-
-    circuitState.cycle()
-
-    for (elem <- blackBoxFactories) {
-      elem.cycle()
-    }
-
-    log(s"check prints")
-    evaluator.checkPrints()
-    log(s"check stops")
-    lastStopResult = evaluator.checkStops()
-
-    if(stopped) {
-      if(stopResult == 0) {
-        throw StopException(s"Success: Stop result $stopResult")
+        log(s"process reset")
+        evaluateCircuit()
       }
       else {
-        throw StopException(s"Failure: Stop result $stopResult")
+        log(s"interpreter cycle() called, state is fresh")
       }
+
+      circuitState.cycle()
+
+      for (elem <- blackBoxFactories) {
+        elem.cycle()
+      }
+
+      log(s"check prints")
+      evaluator.checkPrints()
+      log(s"check stops")
+      lastStopResult = evaluator.checkStops()
+
+      if (stopped) {
+        if (stopResult == 0) {
+          throw StopException(s"Success: Stop result $stopResult")
+        }
+        else {
+          throw StopException(s"Failure: Stop result $stopResult")
+        }
+      }
+
+      evaluateCircuit()
+      log(s"cycle complete:\n${circuitState.prettyString()}")
+
+      if (showState) println(s"FirrtlTerp: next state computed ${"=" * 80}\n${circuitState.prettyString()}")
     }
-
-    evaluateCircuit()
-    log(s"cycle complete:\n${circuitState.prettyString()}")
-
-    if(showState) println(s"FirrtlTerp: next state computed ${"="*80}\n${circuitState.prettyString()}")
+    catch {
+      case e: Throwable =>
+        circuitState.writeVCD()
+        throw e
+    }
   }
 
   def doCycles(n: Int): Unit = {

--- a/src/main/scala/firrtl_interpreter/InterpretiveTester.scala
+++ b/src/main/scala/firrtl_interpreter/InterpretiveTester.scala
@@ -49,6 +49,7 @@ class InterpretiveTester(input: String, optionsManager: HasInterpreterSuite = ne
   private var failureTime = -1L
   private var failCode: Option[Int] = None
   def fail(code: Int): Unit = {
+    interpreter.circuitState.writeVCD()
     if (failCode.isEmpty) {
       failureTime = System.nanoTime()
       failCode = Some(code)


### PR DESCRIPTION
If write VCD is enabled and interpreter gets and exception
or a stop occurs in the circuit. Write out the VCD file if at all
possible.