### PR TITLE
Interactive FirrtlRepl do not run on windows.

### DIFF
--- a/src/main/scala/firrtl_interpreter/FirrtlRepl.scala
+++ b/src/main/scala/firrtl_interpreter/FirrtlRepl.scala
@@ -2,6 +2,7 @@
 package firrtl_interpreter
 
 import java.io.File
+import java.util.regex.Matcher
 
 import firrtl_interpreter.vcd.VCD
 
@@ -31,7 +32,7 @@ class FirrtlRepl(val optionsManager: InterpreterOptionsManager with HasReplConfi
 
   val terminal: Terminal = TerminalFactory.create()
   val console = new ConsoleReader
-  private val historyPath = "~/.firrtl_repl_history".replaceFirst("^~",System.getProperty("user.home"))
+  private val historyPath = "~/.firrtl_repl_history".replaceFirst("^~",Matcher.quoteReplacement(System.getProperty("user.home")))
   val historyFile = new File(historyPath)
   if(! historyFile.exists()) {
     println(s"creating ${historyFile.getName}")


### PR DESCRIPTION
Driver.executeFirrtlRepl(...) do not run on windows and report error:
	-creating .firrtl_repl_history...
	-java.io.IOException: The system cannot find the path specified
because interpreter code internal use System.getProperty("user.home") to get the user's home path as replacement string, but returned path include '\' unquoted. which lead to create file failed. with this fix, interactive interpreter run good on windows.