### PR TITLE
Fix CheckInitialization errors on clock and reset in tests

### DIFF
--- a/src/test/resources/VcdAdder.fir
+++ b/src/test/resources/VcdAdder.fir
@@ -18,6 +18,8 @@ circuit VcdAdder :
 
     inst do_add of DoAdd
 
+    do_add.clock <= clock
+
     do_add.a <= io_a
     do_add.b <= io_b
 

--- a/src/test/resources/three_deep.fir
+++ b/src/test/resources/three_deep.fir
@@ -7,6 +7,8 @@ circuit Top :
 
         inst level2 of Level2
 
+        level2.clk <= clk
+        level2.reset <= reset
         level2.addr <= addr
         data <= level2.data
 
@@ -18,6 +20,8 @@ circuit Top :
 
         inst memory of Level3
 
+        memory.clk <= clk
+        memory.reset <= reset
         memory.addr <= addr
         data <= memory.data
 
@@ -37,6 +41,8 @@ circuit Top :
 
         inst level1 of Level1
 
+        level1.clk <= clk
+        level1.reset <= reset
         level1.addr <= addr
         data <= level1.data
 


### PR DESCRIPTION
Reset and Clock not being wired up caused initialization checks
connect clock and resets in three_deep.fir
connect clock in VcdAdder.fir
Could not produce error in Issue #106 but I am pretty sure this is the cause