### PR TITLE
Special case that must have accidentally been correct before.

### DIFF
--- a/src/main/scala/firrtl_interpreter/vcd/VCD.scala
+++ b/src/main/scala/firrtl_interpreter/vcd/VCD.scala
@@ -736,9 +736,12 @@ case class Change(wire: Wire, value: BigInt, uninitialized: Boolean = false) {
   }
 
   private def serializeUninitialized: String = {
-    "b" +
-      (wire.width - 1 to 0 by -1).map { _ => "x" }.mkString("") +
-      s" ${wire.id}"
+    if(wire.width == 1) {
+      s"x${wire.id}"
+    }
+    else {
+      "b" + (wire.width - 1 to 0 by -1).map { _ => "x" }.mkString("") + s" ${wire.id}"
+    }
   }
 }
 


### PR DESCRIPTION
Width one 'x' wires must be written in
x{id}
format instead of
bx {id}
This causes GTKwave to fail parsing.