### PR TITLE
Add mill support

### DIFF
--- a/CommonBuild.sc
+++ b/CommonBuild.sc
@@ -1,0 +1,29 @@
+def scalacOptionsVersion(scalaVersion: String): Seq[String] = {
+  Seq() ++ {
+    // If we're building with Scala > 2.11, enable the compile option
+    //  switch to support our anonymous Bundle definitions:
+    //  https://github.com/scala/bug/issues/10047
+    if (scalaVersion.startsWith("2.11.")) {
+      Seq()
+    } else {
+      Seq(
+        "-Xsource:2.11",
+        "-Ywarn-unused:imports",
+        "-Ywarn-unused:locals"
+      )
+    }
+  }
+}
+
+def javacOptionsVersion(scalaVersion: String): Seq[String] = {
+  Seq() ++ {
+    // Scala 2.12 requires Java 8. We continue to generate
+    //  Java 7 compatible code for Scala 2.11
+    //  for compatibility with old clients.
+    if (scalaVersion.startsWith("2.11.")) {
+      Seq("-source", "1.7", "-target", "1.7")
+    } else {
+      Seq("-source", "1.8", "-target", "1.8")
+    }
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,10 @@
 root_dir ?= $(PWD)
-regress_dir ?= $(root_dir)/regress
-install_dir ?= $(root_dir)/utils/bin
 
 SBT ?= sbt
 SBT_FLAGS ?= -Dsbt.log.noformat=true
 MKDIR ?= mkdir -p
 CURL ?= curl -L
 MILL_BIN ?= $(HOME)/bin/mill
-# The following must correspond with the equivalent definition in build.sc
-ANTLR4_JAR ?= $(HOME)/lib/antlr-4.7.1-complete.jar
 MILL ?= $(MILL_BIN) --color false
 
 # Ensure the default target is something reasonable.
@@ -19,66 +15,40 @@ $(MILL_BIN):
 	$(MKDIR) $(dir $@)
 	$(CURL) -o $@ https://github.com/ucbjrl/mill/releases/download/v0.2.0-FDF/mill-0.2.0-FDF && chmod +x $@
 
-# Fetch antlr4 (if we don't have it.
-$(ANTLR4_JAR):
-	$(MKDIR) $(dir $@)
-	$(CURL) -o $@ https://www.antlr.org/download/antlr-4.7.1-complete.jar	
-mill-tools:	$(MILL_BIN) $(ANTLR4_JAR)
+mill-tools:	$(MILL_BIN)
 
 # Compile and package jar
 mill.build: mill-tools
-	$(MILL) firrtl.jar
+	$(MILL) firrtlInterpreter.jar
 
 # Compile and test
 mill.test: mill-tools
-	$(MILL) firrtl.test
+	$(MILL) firrtlInterpreter.test
 
 # Build and publish jar
 mill.publishLocal: mill-tools
-	$(MILL) firrtl.publishLocal
+	$(MILL) firrtlInterpreter.publishLocal
 
 # Compile and package all jar
 mill.build.all: mill-tools
-	$(MILL) firrtl[_].jar
+	$(MILL) firrtlInterpreter[_].jar
 
 # Compile and test
 mill.test.all: mill-tools
-	$(MILL) firrtl[_].test
+	$(MILL) firrtlInterpreter[_].test
 
 # Build and publish jar
 mill.publishLocal.all: mill-tools
-	$(MILL) firrtl[_].publishLocal
+	$(MILL) firrtlInterpreter[_].publishLocal
 
 # Remove all generated code.
 # Until "mill clean" makes it into a release.
 mill.clean:
 	$(RM) -rf out
 
-scala_jar ?= $(install_dir)/firrtl.jar
-scala_src := $(shell find src -type f \( -name "*.scala" -o -path "*/resources/*" \))
+clean:	mill.clean
+	$(SBT) "+clean"
 
-clean:
-	rm -f $(install_dir)/firrtl.jar
-	$(SBT) "clean"
+build:	mill.build
 
-build:	build-scala
-
-regress: $(scala_jar)
-	cd $(regress_dir) && $(install_dir)/firrtl -i rocket.fir -o rocket.v -X verilog
-
-# Scala Added Makefile commands
-
-build-scala: $(scala_jar)
-
-$(scala_jar): $(scala_src)
-	$(SBT) "assembly"
-
-test-scala:
-	$(SBT) test
-
-jenkins-build:	clean
-	$(SBT) $(SBT_FLAGS) +clean +test +publish-local
-	$(SBT) $(SBT_FLAGS) scalastyle coverage test
-	$(SBT) $(SBT_FLAGS) coverageReport
-
-.PHONY: build clean regress build-scala test-scala
+.PHONY: build clean mill.build mill.test mill.publishLocal mill.build.all mill.test.all mill.publishLocal.all

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,84 @@
+root_dir ?= $(PWD)
+regress_dir ?= $(root_dir)/regress
+install_dir ?= $(root_dir)/utils/bin
+
+SBT ?= sbt
+SBT_FLAGS ?= -Dsbt.log.noformat=true
+MKDIR ?= mkdir -p
+CURL ?= curl -L
+MILL_BIN ?= $(HOME)/bin/mill
+# The following must correspond with the equivalent definition in build.sc
+ANTLR4_JAR ?= $(HOME)/lib/antlr-4.7.1-complete.jar
+MILL ?= $(MILL_BIN) --color false
+
+# Ensure the default target is something reasonable.
+default: build
+
+# Fetch mill (if we don't have it.
+$(MILL_BIN):
+	$(MKDIR) $(dir $@)
+	$(CURL) -o $@ https://github.com/ucbjrl/mill/releases/download/v0.2.0-FDF/mill-0.2.0-FDF && chmod +x $@
+
+# Fetch antlr4 (if we don't have it.
+$(ANTLR4_JAR):
+	$(MKDIR) $(dir $@)
+	$(CURL) -o $@ https://www.antlr.org/download/antlr-4.7.1-complete.jar	
+mill-tools:	$(MILL_BIN) $(ANTLR4_JAR)
+
+# Compile and package jar
+mill.build: mill-tools
+	$(MILL) firrtl.jar
+
+# Compile and test
+mill.test: mill-tools
+	$(MILL) firrtl.test
+
+# Build and publish jar
+mill.publishLocal: mill-tools
+	$(MILL) firrtl.publishLocal
+
+# Compile and package all jar
+mill.build.all: mill-tools
+	$(MILL) firrtl[_].jar
+
+# Compile and test
+mill.test.all: mill-tools
+	$(MILL) firrtl[_].test
+
+# Build and publish jar
+mill.publishLocal.all: mill-tools
+	$(MILL) firrtl[_].publishLocal
+
+# Remove all generated code.
+# Until "mill clean" makes it into a release.
+mill.clean:
+	$(RM) -rf out
+
+scala_jar ?= $(install_dir)/firrtl.jar
+scala_src := $(shell find src -type f \( -name "*.scala" -o -path "*/resources/*" \))
+
+clean:
+	rm -f $(install_dir)/firrtl.jar
+	$(SBT) "clean"
+
+build:	build-scala
+
+regress: $(scala_jar)
+	cd $(regress_dir) && $(install_dir)/firrtl -i rocket.fir -o rocket.v -X verilog
+
+# Scala Added Makefile commands
+
+build-scala: $(scala_jar)
+
+$(scala_jar): $(scala_src)
+	$(SBT) "assembly"
+
+test-scala:
+	$(SBT) test
+
+jenkins-build:	clean
+	$(SBT) $(SBT_FLAGS) +clean +test +publish-local
+	$(SBT) $(SBT_FLAGS) scalastyle coverage test
+	$(SBT) $(SBT_FLAGS) coverageReport
+
+.PHONY: build clean regress build-scala test-scala

--- a/build.sc
+++ b/build.sc
@@ -1,0 +1,125 @@
+import ammonite.ops._
+import ammonite.ops.ImplicitWd._
+import mill._
+import mill.scalalib._
+import mill.scalalib.publish._
+import mill.eval.Evaluator
+
+import $file.CommonBuild
+
+// An sbt layout with src in the top directory.
+trait CrossUnRootedSbtModule extends CrossSbtModule {
+  override def millSourcePath = super.millSourcePath / ammonite.ops.up
+}
+
+trait CommonModule extends CrossUnRootedSbtModule with PublishModule {
+  def publishVersion = "1.2-SNAPSHOT"
+
+  def pomSettings = PomSettings(
+    description = artifactName(),
+    organization = "edu.berkeley.cs",
+    url = "https://github.com/freechipsproject/firrtl.git",
+    licenses = Seq(License.`BSD-3-Clause`),
+    versionControl = VersionControl.github("freechipsproject", "firrtl"),
+    developers = Seq(
+      Developer("jackbackrack",    "Jonathan Bachrach",      "https://eecs.berkeley.edu/~jrb/")
+    )
+  )
+
+  override def scalacOptions = Seq(
+    "-deprecation",
+    "-explaintypes",
+    "-feature", "-language:reflectiveCalls",
+    "-unchecked",
+    "-Xcheckinit",
+    "-Xlint:infer-any",
+    "-Xlint:missing-interpolator"
+  ) ++ CommonBuild.scalacOptionsVersion(crossScalaVersion)
+
+  override def javacOptions = CommonBuild.javacOptionsVersion(crossScalaVersion)
+}
+
+// Generic antlr4 configuration.
+// This could be simpler, but I'm trying to keep some compatibility with the sbt plugin.
+case class Antlr4Config(val sourcePath: Path) {
+  val ANTLR4_JAR = (home / 'lib / "antlr-4.7.1-complete.jar").toString
+  val antlr4GenVisitor: Boolean = true
+  val antlr4GenListener: Boolean = false
+  val antlr4PackageName: Option[String] = Some("firrtl.antlr")
+  val antlr4Version: String = "4.7"
+
+  val listenerArg: String = if (antlr4GenListener) "-listener" else "-no-listener"
+  val visitorArg: String = if (antlr4GenVisitor) "-visitor" else "-no-visitor"
+  val packageArg: Seq[String] = antlr4PackageName match {
+    case Some(p) => Seq("-package", p)
+    case None => Seq.empty
+  }
+  def runAntlr(outputPath: Path) = {
+    val cmd = Seq[String]("java", "-jar", ANTLR4_JAR, "-o", outputPath.toString, "-lib", sourcePath.toString, listenerArg, visitorArg) ++ packageArg :+ (sourcePath / "FIRRTL.g4").toString
+    val result = %%(cmd)
+  }
+}
+
+val crossVersions = Seq("2.11.12", "2.12.4")
+
+// Make this available to external tools.
+object firrtl extends Cross[FirrtlModule](crossVersions: _*) {
+  def defaultVersion(ev: Evaluator[Any]) = T.command{
+    println(crossVersions.head)
+  }
+
+  def compile = T{
+    firrtl(crossVersions.head).compile()
+  }
+
+  def jar = T{
+    firrtl(crossVersions.head).jar()
+  }
+
+  def test = T{
+    firrtl(crossVersions.head).test.test()
+  }
+
+  def publishLocal = T{
+    firrtl(crossVersions.head).publishLocal()
+  }
+
+  def docJar = T{
+    firrtl(crossVersions.head).docJar()
+  }
+}
+
+class FirrtlModule(val crossScalaVersion: String) extends CommonModule {
+  override def artifactName = "firrtl"
+
+  override def ivyDeps = Agg(
+    ivy"com.typesafe.scala-logging::scala-logging:3.7.2",
+    ivy"ch.qos.logback:logback-classic:1.2.3",
+    ivy"com.github.scopt::scopt:3.6.0",
+    ivy"net.jcazevedo::moultingyaml:0.4.0",
+    ivy"org.json4s::json4s-native:3.5.3",
+    ivy"org.antlr:antlr4-runtime:4.7"
+  )
+
+  object test extends Tests {
+    override def ivyDeps = Agg(
+      ivy"org.scalatest::scalatest:3.0.1",
+      ivy"org.scalacheck::scalacheck:1.13.4"
+    )
+    def testFrameworks = Seq("org.scalatest.tools.Framework")
+  }
+
+  def generateAntlrSources(p: Path, sourcePath: Path) = {
+    val antlr = new Antlr4Config(sourcePath)
+    antlr.runAntlr(p)
+    p
+  }
+
+  def antlrSourceRoot = T.sources{ pwd / 'src / 'main / 'antlr4 }
+
+  override def generatedSources = T {
+    val sourcePath: Path = antlrSourceRoot().head.path
+    val p = Seq(PathRef(generateAntlrSources(T.ctx().dest, sourcePath)))
+    p
+  }
+}

--- a/build.sc
+++ b/build.sc
@@ -18,11 +18,11 @@ trait CommonModule extends CrossUnRootedSbtModule with PublishModule {
   def pomSettings = PomSettings(
     description = artifactName(),
     organization = "edu.berkeley.cs",
-    url = "https://github.com/freechipsproject/firrtl.git",
+    url = "https://github.com/freechipsproject/firrtl-interpreter.git",
     licenses = Seq(License.`BSD-3-Clause`),
-    versionControl = VersionControl.github("freechipsproject", "firrtl"),
+    versionControl = VersionControl.github("freechipsproject", "firrtl-interpreter"),
     developers = Seq(
-      Developer("jackbackrack",    "Jonathan Bachrach",      "https://eecs.berkeley.edu/~jrb/")
+      Developer("chick",    "Charles Markley",      "https://aspire.eecs.berkeley.edu/author/chick/")
     )
   )
 
@@ -39,67 +39,51 @@ trait CommonModule extends CrossUnRootedSbtModule with PublishModule {
   override def javacOptions = CommonBuild.javacOptionsVersion(crossScalaVersion)
 }
 
-// Generic antlr4 configuration.
-// This could be simpler, but I'm trying to keep some compatibility with the sbt plugin.
-case class Antlr4Config(val sourcePath: Path) {
-  val ANTLR4_JAR = (home / 'lib / "antlr-4.7.1-complete.jar").toString
-  val antlr4GenVisitor: Boolean = true
-  val antlr4GenListener: Boolean = false
-  val antlr4PackageName: Option[String] = Some("firrtl.antlr")
-  val antlr4Version: String = "4.7"
-
-  val listenerArg: String = if (antlr4GenListener) "-listener" else "-no-listener"
-  val visitorArg: String = if (antlr4GenVisitor) "-visitor" else "-no-visitor"
-  val packageArg: Seq[String] = antlr4PackageName match {
-    case Some(p) => Seq("-package", p)
-    case None => Seq.empty
-  }
-  def runAntlr(outputPath: Path) = {
-    val cmd = Seq[String]("java", "-jar", ANTLR4_JAR, "-o", outputPath.toString, "-lib", sourcePath.toString, listenerArg, visitorArg) ++ packageArg :+ (sourcePath / "FIRRTL.g4").toString
-    val result = %%(cmd)
-  }
-}
-
 val crossVersions = Seq("2.11.12", "2.12.4")
 
 // Make this available to external tools.
-object firrtl extends Cross[FirrtlModule](crossVersions: _*) {
+object firrtlInterpreter extends Cross[FirrtlInterpreterModule](crossVersions: _*) {
   def defaultVersion(ev: Evaluator[Any]) = T.command{
     println(crossVersions.head)
   }
 
   def compile = T{
-    firrtl(crossVersions.head).compile()
+    firrtlInterpreter(crossVersions.head).compile()
   }
 
   def jar = T{
-    firrtl(crossVersions.head).jar()
+    firrtlInterpreter(crossVersions.head).jar()
   }
 
   def test = T{
-    firrtl(crossVersions.head).test.test()
+    firrtlInterpreter(crossVersions.head).test.test()
   }
 
   def publishLocal = T{
-    firrtl(crossVersions.head).publishLocal()
+    firrtlInterpreter(crossVersions.head).publishLocal()
   }
 
   def docJar = T{
-    firrtl(crossVersions.head).docJar()
+    firrtlInterpreter(crossVersions.head).docJar()
   }
 }
 
-class FirrtlModule(val crossScalaVersion: String) extends CommonModule {
-  override def artifactName = "firrtl"
+// Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
+val defaultVersions = Map("firrtl" -> "1.2-SNAPSHOT")
+
+def getVersion(dep: String, org: String = "edu.berkeley.cs") = {
+  val version = sys.env.getOrElse(dep + "Version", defaultVersions(dep))
+  ivy"$org::$dep:$version"
+}
+
+class FirrtlInterpreterModule(val crossScalaVersion: String) extends CommonModule {
+  override def artifactName = "firrtl-interpreter"
+
+  def chiselDeps = Agg("firrtl").map { d => getVersion(d) }
 
   override def ivyDeps = Agg(
-    ivy"com.typesafe.scala-logging::scala-logging:3.7.2",
-    ivy"ch.qos.logback:logback-classic:1.2.3",
-    ivy"com.github.scopt::scopt:3.6.0",
-    ivy"net.jcazevedo::moultingyaml:0.4.0",
-    ivy"org.json4s::json4s-native:3.5.3",
-    ivy"org.antlr:antlr4-runtime:4.7"
-  )
+    ivy"org.scala-lang.modules:scala-jline:2.12.1"
+  ) ++ chiselDeps
 
   object test extends Tests {
     override def ivyDeps = Agg(
@@ -109,17 +93,4 @@ class FirrtlModule(val crossScalaVersion: String) extends CommonModule {
     def testFrameworks = Seq("org.scalatest.tools.Framework")
   }
 
-  def generateAntlrSources(p: Path, sourcePath: Path) = {
-    val antlr = new Antlr4Config(sourcePath)
-    antlr.runAntlr(p)
-    p
-  }
-
-  def antlrSourceRoot = T.sources{ pwd / 'src / 'main / 'antlr4 }
-
-  override def generatedSources = T {
-    val sourcePath: Path = antlrSourceRoot().head.path
-    val p = Seq(PathRef(generateAntlrSources(T.ctx().dest, sourcePath)))
-    p
-  }
 }


### PR DESCRIPTION
Inherit mill support from `firrtl`. The (nop) commits prior to May 17, 2018 are a side-effect of inheriting the files from `firrtl`.