### PR TITLE
ServiceLoader META-INF Interpreter, VcdReplay

### DIFF
--- a/src/main/resources/META-INF/services/firrtl.options.RegisteredLibrary
+++ b/src/main/resources/META-INF/services/firrtl.options.RegisteredLibrary
@@ -1,0 +1,4 @@
+firrtl_interpreter.InterpreterLibrary
+firrtl_interpreter.VcdReplayLibrary
+firrtl_interpreter.repl.InterpreterReplLibrary
+firrtl_interpreter.vcd.TreadleReplLibrary

--- a/src/main/scala/firrtl_interpreter/VcdReplayOptions.scala
+++ b/src/main/scala/firrtl_interpreter/VcdReplayOptions.scala
@@ -82,7 +82,7 @@ case object VcdReplayTestAliasedWiresAnnotation extends NoTargetAnnotation with 
     .text("test aliased wires during execution")
 }
 
-object VcdReplayLibrary extends RegisteredLibrary {
+class VcdReplayLibrary extends RegisteredLibrary {
   override def name: String = "vcd-replay"
 
   override def addOptions(parser: OptionParser[AnnotationSeq]): Unit = {

--- a/src/main/scala/firrtl_interpreter/repl/ReplConfig.scala
+++ b/src/main/scala/firrtl_interpreter/repl/ReplConfig.scala
@@ -94,7 +94,7 @@ case class ReplOutputFormatAnnotation(name: String = "d") extends NoTargetAnnota
     .text("default output format when display wire values b, d, x")
 }
 
-object InterpreterReplLibrary extends RegisteredLibrary {
+class InterpreterReplLibrary extends RegisteredLibrary {
   override def name: String = "interpreter-repl"
 
   override def addOptions(parser: OptionParser[AnnotationSeq]): Unit = {
@@ -111,5 +111,3 @@ object InterpreterReplLibrary extends RegisteredLibrary {
     seq.foreach(_.addOptions(parser))
   }
 }
-
-

--- a/src/main/scala/firrtl_interpreter/vcd/VCDConfig.scala
+++ b/src/main/scala/firrtl_interpreter/vcd/VCDConfig.scala
@@ -85,7 +85,7 @@ case class VcdNewVarPrefixAnnotation(name: String = "") extends NoTargetAnnotati
     .text("change vars prefix vars to this")
 }
 
-object TreadleReplLibrary extends RegisteredLibrary {
+class TreadleReplLibrary extends RegisteredLibrary {
   override def name: String = "vcd-replay"
 
   override def addOptions(parser: OptionParser[AnnotationSeq]): Unit = {


### PR DESCRIPTION
Without this, the children of `RegisteredLibrary` aren't registered... The error is super annoying as there's no good way to know if the user added a bogus option or if they wrote a library and forgot to include a `src/main/resources/META-INF/services` entry. (With high probability it's the former due to the prior on the number of library writers.)

Note: this is only as an example of what is missing. I'm not entirely sure that all of these should be registered. They have long options that are duplicates. FIRRTL erroneously prints the error with their short duplicates. Fixing the FIRRTL PR now.