### PR TITLE
PrimOp changed in Intervals upstreaming

### DIFF
--- a/src/test/scala/firrtl_interpreter/fixedpoint/FixedPointSpec.scala
+++ b/src/test/scala/firrtl_interpreter/fixedpoint/FixedPointSpec.scala
@@ -76,7 +76,7 @@ class FixedPointSpec extends FlatSpec with Matchers {
         |    output io : {flip in : Fixed<6><<2>>, out : Fixed}
         |
         |    io is invalid
-        |    node T_2 = bpset(io.in, 0)
+        |    node T_2 = setp(io.in, 0)
         |    io.out <= T_2
       """.stripMargin
     val tester = new InterpretiveTester(input)


### PR DESCRIPTION
Problem is that treadle keeps raw firrtl around to run tests on.
- The internal api for set precision is now `setp` for both fixed point an interval
- `bpset` is now `setp`