### PR TITLE
Revert "Merge pull request #154 from freechipsproject/interval-setp-fix"

### DIFF
--- a/src/test/scala/firrtl_interpreter/fixedpoint/FixedPointSpec.scala
+++ b/src/test/scala/firrtl_interpreter/fixedpoint/FixedPointSpec.scala
@@ -76,7 +76,7 @@ class FixedPointSpec extends FlatSpec with Matchers {
         |    output io : {flip in : Fixed<6><<2>>, out : Fixed}
         |
         |    io is invalid
-        |    node T_2 = setp(io.in, 0)
+        |    node T_2 = bpset(io.in, 0)
         |    io.out <= T_2
       """.stripMargin
     val tester = new InterpretiveTester(input)


### PR DESCRIPTION
This reverts commit 4a6670144f8579615f53f81459bc51dcf4391145, reversing
changes made to f02f7dd28e88bea10e22768bd83c2e5c804940bb.

**NOTE**: This is for the upcoming 1.2-20191106-SNAPSHOT, which will be interval-free.
