### PR TITLE
Deal with redefinition of logger due to BackendCompilationUtilities update

### DIFF
--- a/src/test/scala/firrtl_interpreter/vcd/VCDSpec.scala
+++ b/src/test/scala/firrtl_interpreter/vcd/VCDSpec.scala
@@ -7,7 +7,7 @@ import firrtl.CommonOptions
 import firrtl.util.BackendCompilationUtilities
 import java.io.File
 
-import logger.LogLevel
+import logger.{Logger, LogLevel}
 import org.scalatest.{FlatSpec, Matchers}
 
 // scalastyle:off magic.number
@@ -217,7 +217,7 @@ class VCDSpec extends FlatSpec with Matchers with BackendCompilationUtilities {
         |
       """.stripMargin
 
-    logger.Logger.setLevel(LogLevel.Debug)
+    Logger.setLevel(LogLevel.Debug)
 
     val manager = new InterpreterOptionsManager {
       interpreterOptions = interpreterOptions.copy(writeVCD = true)


### PR DESCRIPTION
freechipsproject/firrtl@3c8e22dc9e4f033be167aa721e6d8ad54330ca3c extended BackendCompilationUtilities with LazyLogging which effectively undoes the effect of the `protected` in:
```scala
trait LazyLogging {
  protected val logger = new Logger(this.getClass.getName)
}
```
which in turn causes compilation failures for code that expects `logger` to refer to the package, and not some local field.